### PR TITLE
Remove noTitle dialect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,7 @@ export const ChordProLanguage = LRLanguage.define({
         ":": t.punctuation,
         Separator: t.separator
       })
-    ],
-    dialect: "noTitle"
+    ]
   }),
   languageData: {
     commentTokens: {line: "#"}

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -1,7 +1,4 @@
-@dialects { noTitle }
-
 @top Song {
-  (Title { titleText } eol (Author { authorText } eol)?)?
   ((Comment | Directive | LineDirective | Lyrics | blankLine | ChordLine | Section) (eol | eof))*
 }
 
@@ -23,8 +20,6 @@ InlineChord { "[" Chord? "]" }
 @external tokens line from "./tokens.js" {
   Comment
   blankLine
-  titleText
-  authorText
   SectionName
   chordLineStart
   directiveLineStart

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,5 +1,4 @@
-import {titleText, authorText, chordLineStart, directiveLineStart, blankLine, Comment, SectionName, Chord,
-        Dialect_noTitle} from "./syntax.grammar.terms"
+import {chordLineStart, directiveLineStart, blankLine, Comment, SectionName, Chord} from "./syntax.grammar.terms"
 import {ExternalTokenizer, InputStream} from "@lezer/lr"
 
 const enum Ch {
@@ -232,14 +231,6 @@ export const line = new ExternalTokenizer((input, stack) => {
     return
   } else if (hasDirectiveName(input)) {
     input.acceptToken(directiveLineStart)
-  } else if (!stack.dialectEnabled(Dialect_noTitle) && stack.canShift(titleText) && wordChar(input.next)) {
-    skipLine(input)
-    input.acceptToken(titleText)
-    return
-  } else if (!stack.dialectEnabled(Dialect_noTitle) && stack.canShift(authorText) && wordChar(input.next)) {
-    skipLine(input)
-    input.acceptToken(authorText)
-    return
   } else if (readChord(input)) {
     // See if this is a chord-only line
     for (;;) {

--- a/test/chordpro-chords.txt
+++ b/test/chordpro-chords.txt
@@ -1,4 +1,4 @@
-# Symbols {"dialect": "noTitle"}
+# Symbols
 
 [C2/E]
 [Dbm7]
@@ -6,45 +6,45 @@
 
 ==> Song(Lyrics(InlineChord(Chord)), Lyrics(InlineChord(Chord)), Lyrics(InlineChord(Chord)))
 
-# Numeric - minor {"dialect": "noTitle"}
+# Numeric - minor
 
 [2m]
 
 ==> Song(Lyrics(InlineChord(Chord)))
 
-# Numeric - accidentals {"dialect": "noTitle"}
+# Numeric - accidentals
 
 [#4m7]
 [b7]
 
 ==> Song(Lyrics(InlineChord(Chord)), Lyrics(InlineChord(Chord)))
 
-# Numeric - bass {"dialect": "noTitle"}
+# Numeric - bass
 
 [4/1]
 
 ==> Song(Lyrics(InlineChord(Chord)))
 
-# Numeral {"dialect": "noTitle"}
+# Numeral
 
 [V13]
 
 ==> Song(Lyrics(InlineChord(Chord)))
 
-# Numeral - accidentals {"dialect": "noTitle"}
+# Numeral - accidentals
 
 [bVII]
 [#IV]
 
 ==> Song(Lyrics(InlineChord(Chord)), Lyrics(InlineChord(Chord)))
 
-# Numeral - bass {"dialect": "noTitle"}
+# Numeral - bass
 
 [IV/I]
 
 ==> Song(Lyrics(InlineChord(Chord)))
 
-# no chord {"dialect": "noTitle"}
+# no chord
 
 []
 

--- a/test/chordpro.txt
+++ b/test/chordpro.txt
@@ -1,4 +1,4 @@
-# Lyrics {"dialect": "noTitle"}
+# Lyrics
 
 My [Dm7]heart has always [C/E]longed for something[F] more
 
@@ -7,7 +7,7 @@ My [Dm7]heart has always [C/E]longed for something[F] more
 Song(
   Lyrics(Lyric,InlineChord(Chord),Lyric,InlineChord(Chord),Lyric,InlineChord(Chord),Lyric))
 
-# Allows dangling ] {"dialect": "noTitle"}
+# Allows dangling ]
 
 Let it [Am]be
 [C]Whisper wor]ds of [F]wis[G]dom
@@ -18,7 +18,7 @@ Song(
   Lyrics(Lyric,InlineChord(Chord),Lyric),
   Lyrics(InlineChord(Chord),Lyric,InlineChord(Chord),Lyric,InlineChord(Chord),Lyric))
 
-# Allows dangling } {"dialect": "noTitle"}
+# Allows dangling }
 
 Let it [Am]be
 [C]Whisper wor}ds of [F]wis[G]dom
@@ -29,7 +29,7 @@ Song(
   Lyrics(Lyric,InlineChord(Chord),Lyric),
   Lyrics(InlineChord(Chord),Lyric,InlineChord(Chord),Lyric,InlineChord(Chord),Lyric))
 
-# Inline directives {"dialect": "noTitle"}
+# Inline directives
 
 {start_of_chorus}
 {c:Chorus 1}
@@ -50,7 +50,7 @@ Song(
     InlineChord(Chord)),
   Directive(DirectiveName))
 
-# Directive mid-verse {"dialect": "noTitle"}
+# Directive mid-verse
 
 {c:Chorus}
 And [Bb]I,[F/A][Gm][Bbma7/D]\ I'm desperate [Eb]for You[Gm7][Fsus][F]
@@ -77,7 +77,7 @@ Song(
     Separator,Lyric,InlineChord(Chord),Lyric,InlineChord(Chord),Lyric,InlineChord(Chord),Lyric,
     InlineChord(Chord)))
 
-# Meta with multiple sections {"dialect": "noTitle"}
+# Meta with multiple sections
 
 {t: Rattle}
 {key: Eb}

--- a/test/chords-over-words-chords.txt
+++ b/test/chords-over-words-chords.txt
@@ -1,4 +1,4 @@
-# Symbols {"dialect": "noTitle"}
+# Symbols
 
 C2/E
 Dbm7
@@ -6,13 +6,13 @@ Dbm7
 
 ==> Song(ChordLine(Chord), ChordLine(Chord), ChordLine(Chord))
 
-# Numeric - minor {"dialect": "noTitle"}
+# Numeric - minor
 
 2m
 
 ==> Song(ChordLine(Chord))
 
-# Numeric - accidentals {"dialect": "noTitle"}
+# Numeric - accidentals
 
 #4m7
 
@@ -20,26 +20,26 @@ b7
 
 ==> Song(ChordLine(Chord), ChordLine(Chord))
 
-# Numeric - bass {"dialect": "noTitle"}
+# Numeric - bass
 
 4/1
 
 ==> Song(ChordLine(Chord))
 
-# Numeral {"dialect": "noTitle"}
+# Numeral
 
 V13
 
 ==> Song(ChordLine(Chord))
 
-# Numeral - accidentals {"dialect": "noTitle"}
+# Numeral - accidentals
 
 bVII
 IV
 
 ==> Song(ChordLine(Chord), ChordLine(Chord))
 
-# Numeral - bass {"dialect": "noTitle"}
+# Numeral - bass
 
 iv/I
 

--- a/test/chords-over-words.txt
+++ b/test/chords-over-words.txt
@@ -1,4 +1,4 @@
-# Simple {"dialect": "noTitle"}
+# Simple
 
    Dm7              C/E                 F#
 My heart has always longed for something   more
@@ -7,7 +7,7 @@ My heart has always longed for something   more
 
 Song(ChordLine(Chord,Chord,Chord),Lyrics(Lyric))
 
-# Simple - Numbers {"dialect": "noTitle"}
+# Simple - Numbers
 
    2m7              2/3                 #4
 My heart has always longed for something  more
@@ -16,7 +16,7 @@ My heart has always longed for something  more
 
 Song(ChordLine(Chord,Chord,Chord),Lyrics(Lyric))
 
-# Simple - Numerals {"dialect": "noTitle"}
+# Simple - Numerals
 
    ii7              II/III              #IV
 My heart has always longed for something   more
@@ -25,7 +25,7 @@ My heart has always longed for something   more
 
 Song(ChordLine(Chord,Chord,Chord),Lyrics(Lyric))
 
-# Backslash should have it's own token {"dialect": "noTitle"}
+# Backslash should have it's own token
 
    Dm7               C/E                 F
 My heart has always \longed for something  more
@@ -43,9 +43,9 @@ Intro (5x)
 Eb(no3) / / / | / / / / |
 
 Verse 1
-Eb                   Ebsus         Eb      
+Eb                   Ebsus         Eb
 Saturday was silent, surely it was through
-Cm                         Bb        Ab2  Eb/G    Eb  / / / / 
+Cm                         Bb        Ab2  Eb/G    Eb  / / / /
    But since when has im - possible\ ever stopped You
 
 ==>
@@ -67,9 +67,9 @@ Intro (5x)
 Eb(no3) / / / | / / / / |
 
 Verse 1
-Eb                   Ebsus         Eb      
+Eb                   Ebsus         Eb
 Saturday was silent, surely it was through
-Cm                         Bb        Ab2  Eb/G    Eb  / / / / 
+Cm                         Bb        Ab2  Eb/G    Eb  / / / /
    But since when has im - possible\ ever stopped You
 
 ==>
@@ -86,10 +86,10 @@ Song(
 # Directive mid-section
 
 Verse 1
-Eb                   Ebsus         Eb      
+Eb                   Ebsus         Eb
 Saturday was silent, surely it was through
 transpose: 2
-Cm                         Bb        Ab2  Eb/G    Eb  / / / / 
+Cm                         Bb        Ab2  Eb/G    Eb  / / / /
    But since when has im - possible\ ever stopped You
 
 ==>
@@ -105,16 +105,16 @@ Song(
 # Space Mid-Section
 
 Chorus 1:
-Eb5                                     /Bb - /Ab Eb5 
+Eb5                                     /Bb - /Ab Eb5
 This is the sound\ of dry bones rattling
-Eb5                                           /Bb - /Ab Eb5 
+Eb5                                           /Bb - /Ab Eb5
 This is the praise\ make a dead man walk again
 
-         Cm                Bb  
+         Cm                Bb
 Open the grave, I'm coming out
-          Ab                   Eb   
+          Ab                   Eb
 I'm gonna live, gonna live a - gain
-Eb5                                     Ab - Eb/G Eb5 
+Eb5                                     Ab - Eb/G Eb5
 This is the sound\ of dry bones rattling
 Ab - Eb/G Eb5 / | Ab - Eb/G Eb5 /
 

--- a/test/directives.txt
+++ b/test/directives.txt
@@ -1,17 +1,17 @@
-# meta {"dialect": "chordpro"}
+# meta
 {capo: 2}
 {artist: Maverick City Music}
 ==> Song(Directive(DirectiveName, DirectiveValue), Directive(DirectiveName, DirectiveValue))
 
-# alias {"dialect": "chordpro"}
+# alias
 {t: Get Back}
 ==> Song(Directive(DirectiveName, DirectiveValue))
 
-# escapes special characters {"dialect": "chordpro"}
+# escapes special characters
 {title: my \{title\}}
 ==> Song(Directive(DirectiveName, DirectiveValue))
 
-# inline {"dialect": "chordpro"}
+# inline
 {start_of_verse}
 ==> Song(Directive("{", DirectiveName, "}"))
 


### PR DESCRIPTION
This removes the `noTitle` dialect and syntax matching for title and artist.  I think this was to support the chords over words syntax (which probalby should be a separate dialect, or separate grammar entirely) where the first two lines are freeform text and assumed to be title and artist.

@isaiahdahl did you have plans to use this?